### PR TITLE
List inline level fix

### DIFF
--- a/src/styles/scss/components/_typography.scss
+++ b/src/styles/scss/components/_typography.scss
@@ -104,7 +104,7 @@ ul, ol {
   &.list-inline {
     padding: 0;
 
-    li {
+    > li {
       display: inline-block;
     }
   }


### PR DESCRIPTION
Niepotrzebne dziedzicznie, jeśli w głównym menu o klasie "list-inline" jest np. sub menu z kolejną listą ul li.
